### PR TITLE
Library for SimH Standard magnetic tape images

### DIFF
--- a/index/si/simh_tapes/simh_tapes-0.1.1-dev.toml
+++ b/index/si/simh_tapes/simh_tapes-0.1.1-dev.toml
@@ -1,0 +1,20 @@
+name = "simh_tapes"
+description = "Library to handle SimH Standard magnetic tape image files"
+version = "0.1.1-dev"
+
+authors = ["Stephen Merrony"]
+maintainers = ["Stephen Merrony <merrony@gmail.com>"]
+maintainers-logins = ["SMerrony"]
+licenses = "AGPL-3.0-or-later"
+website = "https://github.com/SMerrony/simh_tapes"
+tags = ["legacy", "magtape", "magnetic", "tape", "emulation", "simulation"]
+executables = ["simhtapetool"]
+
+[build-switches]
+development.optimization = ["-O0"]
+
+
+[origin]
+commit = "bd6d4853bebc5a6deea0b8869e0969febb1a3eb5"
+url = "git+https://github.com/SMerrony/simh_tapes.git"
+


### PR DESCRIPTION
Simh_tape is an Ada package for handling magnetic tape images in the
[standard format](http://simh.trailing-edge.com/docs/simh_magtape.pdf) used by 
[SimH](http://simh.trailing-edge.com/) and many other computer simulators and emulators.